### PR TITLE
Removed a useless dependency on zend-stdlib for most usages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "php": ">=5.5"
     },
     "require-dev": {
         "zendframework/zend-http": "~2.5",
         "zendframework/zend-server": "~2.5",
+        "zendframework/zend-stdlib": "~2.5",
         "zendframework/zendxml": "~1.0",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
@@ -26,6 +26,7 @@
     "suggest": {
         "zendframework/zend-http": "Zend\\Http component",
         "zendframework/zend-server": "Zend\\Server component",
+        "zendframework/zend-stdlib": "To use the cache for Zend\\Server",
         "zendframework/zendxml": "To support Zend\\Json\\Json::fromXml() usage"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
StdLib is used only for the server cache, and so is useless for anyone using zend-json only to encode and decode json
