### PR TITLE
Updates requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -7,34 +7,32 @@
         "json"
     ],
     "homepage": "https://github.com/zendframework/zend-json",
-    "autoload": {
-        "psr-4": {
-            "Zend\\Json\\": "src/"
-        }
-    },
-    "require": {
-        "php": ">=5.5"
-    },
-    "require-dev": {
-        "zendframework/zend-http": "~2.5",
-        "zendframework/zend-server": "~2.5",
-        "zendframework/zend-stdlib": "~2.5",
-        "zendframework/zendxml": "~1.0",
-        "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0"
-    },
-    "suggest": {
-        "zendframework/zend-http": "Zend\\Http component",
-        "zendframework/zend-server": "Zend\\Server component",
-        "zendframework/zend-stdlib": "To use the cache for Zend\\Server",
-        "zendframework/zendxml": "To support Zend\\Json\\Json::fromXml() usage"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-master": "2.6-dev",
             "dev-develop": "2.7-dev"
+        }
+    },
+    "require": {
+        "php": "^5.5 || ^7.0"
+    },
+    "require-dev": {
+        "zendframework/zend-http": "^2.5.4",
+        "zendframework/zend-server": "^2.6.1",
+        "zendframework/zend-stdlib": "^2.5 || ^3.0",
+        "zendframework/zendxml": "^1.0.2",
+        "fabpot/php-cs-fixer": "1.7.*",
+        "phpunit/PHPUnit": "~4.0"
+    },
+    "suggest": {
+        "zendframework/zend-http": "Zend\\Http component, required to use Zend\\Json\\Server",
+        "zendframework/zend-server": "Zend\\Server component, required to use Zend\\Json\\Server",
+        "zendframework/zend-stdlib": "Zend\\Stdlib component, for use with caching Zend\\Json\\Server responses",
+        "zendframework/zendxml": "To support Zend\\Json\\Json::fromXml() usage"
+    },
+    "autoload": {
+        "psr-4": {
+            "Zend\\Json\\": "src/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
- PHP: `^5.5 || ^7.0`
- require-dev:
  - zend-http => `^2.5.4`
  - zend-server => `^2.6.1`
  - zend-stdlib => `^2.7 || ^3.0`
  - zendxml => `^1.0.2`

These changes will allow updating dependencies and dependent components with forwards-compatibility features.
