### PR TITLE
fix for PHP 7.2, 'Object' is a reserved keyword

### DIFF
--- a/test/JsonTest.php
+++ b/test/JsonTest.php
@@ -483,11 +483,11 @@ class JsonTest extends TestCase
 
     public function testEncodeObject()
     {
-        $actual  = new TestAsset\Object();
+        $actual  = new TestAsset\TestObject();
         $encoded = Json\Encoder::encode($actual);
         $decoded = Json\Decoder::decode($encoded, Json\Json::TYPE_OBJECT);
 
-        $this->assertAttributeEquals(TestAsset\Object::class, '__className', $decoded);
+        $this->assertAttributeEquals(TestAsset\TestObject::class, '__className', $decoded);
         $this->assertAttributeEquals('bar', 'foo', $decoded);
         $this->assertAttributeEquals('baz', 'bar', $decoded);
         $this->assertFalse(isset($decoded->_foo));
@@ -495,9 +495,9 @@ class JsonTest extends TestCase
 
     public function testEncodeClass()
     {
-        $encoded = Json\Encoder::encodeClass(TestAsset\Object::class);
+        $encoded = Json\Encoder::encodeClass(TestAsset\TestObject::class);
 
-        $this->assertContains("Class.create('ZendTest\\Json\\TestAsset\\Object'", $encoded);
+        $this->assertContains("Class.create('ZendTest\\Json\\TestAsset\\TestObject'", $encoded);
         $this->assertContains("ZAjaxEngine.invokeRemoteMethod(this, 'foo'", $encoded);
         $this->assertContains("ZAjaxEngine.invokeRemoteMethod(this, 'bar'", $encoded);
         $this->assertNotContains("ZAjaxEngine.invokeRemoteMethod(this, 'baz'", $encoded);
@@ -508,9 +508,9 @@ class JsonTest extends TestCase
 
     public function testEncodeClasses()
     {
-        $encoded = Json\Encoder::encodeClasses(['ZendTest\Json\TestAsset\Object', 'Zend\Json\Json']);
+        $encoded = Json\Encoder::encodeClasses(['ZendTest\Json\TestAsset\TestObject', 'Zend\Json\Json']);
 
-        $this->assertContains("Class.create('ZendTest\\Json\\TestAsset\\Object'", $encoded);
+        $this->assertContains("Class.create('ZendTest\\Json\\TestAsset\\TestObject'", $encoded);
         $this->assertContains("Class.create('Zend\\Json\\Json'", $encoded);
     }
 

--- a/test/TestAsset/TestObject.php
+++ b/test/TestAsset/TestObject.php
@@ -10,7 +10,7 @@ namespace ZendTest\Json\TestAsset;
 /**
  * Test class for encoding classes.
  */
-class Object
+class TestObject
 {
     const FOO = 'bar';
 


### PR DESCRIPTION
From Fedora QA:
https://apps.fedoraproject.org/koschei/package/php-zendframework-zend-json?collection=f28


```
PHPUnit 5.7.23 by Sebastian Bergmann and contributors.
Runtime:       PHP 7.2.0RC4
Configuration: /builddir/build/BUILD/zend-json-f42a1588e75c2a3e338cd94c37906231e616daab/phpunit.xml.dist
..................................PHP Fatal error:  Cannot use 'Object' as class name as it is reserved in /builddir/build/BUILD/zend-json-f42a1588e75c2a3e338cd94c37906231e616daab/test/TestAsset/Object.php on line 13

```