### PR TITLE
Fix: Do not remove space after comma in string value

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -178,40 +178,43 @@ class Json
             switch ($json[$i]) {
                 case '{':
                 case '[':
-                    if (! $inLiteral) {
-                        $stack[] = $json[$i];
-
-                        $result .= $json[$i];
-                        while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
-                            ++$i;
-                        }
-                        if (isset($json[$i + 1]) && $json[$i + 1] !== '}' && $json[$i + 1] !== ']') {
-                            $result .= "\n" . str_repeat($indentString, count($stack));
-                        }
-                        continue 2;
+                    if ($inLiteral) {
+                        break;
                     }
-                    break;
+
+                    $stack[] = $json[$i];
+
+                    $result .= $json[$i];
+                    while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
+                        ++$i;
+                    }
+                    if (isset($json[$i + 1]) && $json[$i + 1] !== '}' && $json[$i + 1] !== ']') {
+                        $result .= "\n" . str_repeat($indentString, count($stack));
+                    }
+
+                    continue 2;
                 case '}':
                 case ']':
-                    if (! $inLiteral) {
-                        $last = end($stack);
-                        if (($last === '{' && $json[$i] === '}')
-                            || ($last === '[' && $json[$i] === ']')
-                        ) {
-                            array_pop($stack);
-                        }
-
-                        $result .= $json[$i];
-                        while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
-                            ++$i;
-                        }
-                        if (isset($json[$i + 1]) && ($json[$i + 1] === '}' || $json[$i + 1] === ']')) {
-                            $result .= "\n" . str_repeat($indentString, count($stack) - 1);
-                        }
-
-                        continue 2;
+                    if ($inLiteral) {
+                        break;
                     }
-                    break;
+
+                    $last = end($stack);
+                    if (($last === '{' && $json[$i] === '}')
+                        || ($last === '[' && $json[$i] === ']')
+                    ) {
+                        array_pop($stack);
+                    }
+
+                    $result .= $json[$i];
+                    while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
+                        ++$i;
+                    }
+                    if (isset($json[$i + 1]) && ($json[$i + 1] === '}' || $json[$i + 1] === ']')) {
+                        $result .= "\n" . str_repeat($indentString, count($stack) - 1);
+                    }
+
+                    continue 2;
                 case '"':
                     $result .= '"';
 

--- a/src/Json.php
+++ b/src/Json.php
@@ -172,13 +172,13 @@ class Json
         $stack = [];
 
         $result = '';
-        $inValue = false;
+        $inLiteral = false;
 
         for ($i = 0; $i < $length; ++$i) {
             switch ($json[$i]) {
                 case '{':
                 case '[':
-                    if (! $inValue) {
+                    if (! $inLiteral) {
                         $stack[] = $json[$i];
 
                         $result .= $json[$i];
@@ -193,7 +193,7 @@ class Json
                     break;
                 case '}':
                 case ']':
-                    if (! $inValue) {
+                    if (! $inLiteral) {
                         $last = end($stack);
                         if (($last === '{' && $json[$i] === '}')
                             || ($last === '[' && $json[$i] === ']')
@@ -215,8 +215,8 @@ class Json
                 case '"':
                     $result .= '"';
 
-                    if (! $inValue) {
-                        $inValue = true;
+                    if (! $inLiteral) {
+                        $inLiteral = true;
                     } else {
                         $backslashes = 0;
                         $n = $i;
@@ -225,7 +225,7 @@ class Json
                         }
 
                         if (($backslashes % 2) === 0) {
-                            $inValue = false;
+                            $inLiteral = false;
 
                             while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
                                 ++$i;
@@ -238,19 +238,19 @@ class Json
                     }
                     continue 2;
                 case ':':
-                    if (! $inValue) {
+                    if (! $inLiteral) {
                         $result .= ': ';
                         continue 2;
                     }
                     break;
                 case ',':
-                    if (! $inValue) {
+                    if (! $inLiteral) {
                         $result .= ',' . "\n" . str_repeat($indentString, count($stack));
                         continue 2;
                     }
                     break;
                 default:
-                    if (! $inValue && preg_match('/\s/', $json[$i])) {
+                    if (! $inLiteral && preg_match('/\s/', $json[$i])) {
                         continue 2;
                     }
                     break;
@@ -258,7 +258,7 @@ class Json
 
             $result .= $json[$i];
 
-            if (! $inValue) {
+            if (! $inLiteral) {
                 while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
                     ++$i;
                 }

--- a/src/Json.php
+++ b/src/Json.php
@@ -261,14 +261,16 @@ class Json
 
             $result .= $json[$i];
 
-            if (! $inLiteral) {
-                while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
-                    ++$i;
-                }
+            if ($inLiteral) {
+                continue;
+            }
 
-                if (isset($json[$i + 1]) && ($json[$i + 1] === '}' || $json[$i + 1] === ']')) {
-                    $result .= "\n" . str_repeat($indentString, count($stack) - 1);
-                }
+            while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
+                ++$i;
+            }
+
+            if (isset($json[$i + 1]) && ($json[$i + 1] === '}' || $json[$i + 1] === ']')) {
+                $result .= "\n" . str_repeat($indentString, count($stack) - 1);
             }
         }
 

--- a/src/Json.php
+++ b/src/Json.php
@@ -182,10 +182,10 @@ class Json
                         $stack[] = $json[$i];
 
                         $result .= $json[$i];
-                        while (preg_match('/\s/', $json[$i + 1])) {
+                        while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
                             ++$i;
                         }
-                        if ($json[$i + 1] !== '}' && $json[$i + 1] !== ']') {
+                        if (isset($json[$i + 1]) && $json[$i + 1] !== '}' && $json[$i + 1] !== ']') {
                             $result .= "\n" . str_repeat($indentString, count($stack));
                         }
                         continue 2;
@@ -202,10 +202,10 @@ class Json
                         }
 
                         $result .= $json[$i];
-                        while (preg_match('/\s/', $json[$i + 1])) {
+                        while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
                             ++$i;
                         }
-                        if ($json[$i + 1] === '}' || $json[$i + 1] === ']') {
+                        if (isset($json[$i + 1]) && ($json[$i + 1] === '}' || $json[$i + 1] === ']')) {
                             $result .= "\n" . str_repeat($indentString, count($stack) - 1);
                         }
 
@@ -227,11 +227,11 @@ class Json
                         if (($backslashes % 2) === 0) {
                             $inValue = false;
 
-                            while (preg_match('/\s/', $json[$i + 1])) {
+                            while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
                                 ++$i;
                             }
 
-                            if ($json[$i + 1] === '}' || $json[$i + 1] === ']') {
+                            if (isset($json[$i + 1]) && ($json[$i + 1] === '}' || $json[$i + 1] === ']')) {
                                 $result .= "\n" . str_repeat($indentString, count($stack) - 1);
                             }
                         }
@@ -259,11 +259,11 @@ class Json
             $result .= $json[$i];
 
             if (! $inValue) {
-                while (preg_match('/\s/', $json[$i + 1])) {
+                while (isset($json[$i + 1]) && preg_match('/\s/', $json[$i + 1])) {
                     ++$i;
                 }
 
-                if ($json[$i + 1] === '}' || $json[$i + 1] === ']') {
+                if (isset($json[$i + 1]) && ($json[$i + 1] === '}' || $json[$i + 1] === ']')) {
                     $result .= "\n" . str_repeat($indentString, count($stack) - 1);
                 }
             }

--- a/test/JsonTest.php
+++ b/test/JsonTest.php
@@ -1032,6 +1032,32 @@ JSON;
         $this->assertSame($original, $pretty);
     }
 
+    public function testJsonPretty()
+    {
+        $original = <<<JSON
+{
+    "hell\"o": "Level::great",
+    "object": {
+        "val1": "key\\\",
+        "val2": "key{",
+        "val3": "[ ] : "
+    },
+    "arr": [
+        "1",
+        2,
+        true,
+        null,
+        "{ }",
+        "[ ]",
+        ":",
+        " "
+    ]
+}
+JSON;
+
+        $this->assertSame($original, Json\Json::prettyPrint($original));
+    }
+
     public function testPrettyPrintDoublequoteFollowingEscapedBackslashShouldNotBeTreatedAsEscaped()
     {
         $this->assertEquals(
@@ -1043,59 +1069,6 @@ JSON;
             "{\n    \"a\": \"\\\\\"\n}",
             Json\Json::prettyPrint(Json\Json::encode(['a' => '\\']))
         );
-    }
-
-    public function testPrettyPrintEmptyArray()
-    {
-        $original = <<<JSON
-[]
-JSON;
-
-        $this->assertSame($original, Json\Json::prettyPrint($original));
-    }
-
-    public function testPrettyPrintEmptyObject()
-    {
-        $original = <<<JSON
-{}
-JSON;
-
-        $this->assertSame($original, Json\Json::prettyPrint($original));
-    }
-
-    public function testPrettyPrintEmptyProperties()
-    {
-        $original = <<<JSON
-{
-    "foo": [],
-    "bar": {}
-}
-JSON;
-
-        $this->assertSame($original, Json\Json::prettyPrint($original));
-    }
-    public function testPrettyPrintEmptyPropertiesWithWhitespace()
-    {
-        $original = <<<JSON
-{
-"foo": [
-
-            ],
-    "bar": {
-    
-    
-}
-}
-JSON;
-
-        $pretty = <<<JSON
-{
-    "foo": [],
-    "bar": {}
-}
-JSON;
-
-        $this->assertSame($pretty, Json\Json::prettyPrint($original));
     }
 
     public function testPrettyPrintRePrettyPrint()

--- a/test/JsonTest.php
+++ b/test/JsonTest.php
@@ -960,20 +960,70 @@ EOB;
         $this->assertSame($expected, $pretty);
     }
 
+    public function testPrettyPrintEmptyArray()
+    {
+        $original = <<<JSON
+[]
+JSON;
+
+        $this->assertSame($original, Json\Json::prettyPrint($original));
+    }
+
+    public function testPrettyPrintEmptyObject()
+    {
+        $original = <<<JSON
+{}
+JSON;
+
+        $this->assertSame($original, Json\Json::prettyPrint($original));
+    }
+
+    public function testPrettyPrintEmptyProperties()
+    {
+        $original = <<<JSON
+{
+    "foo": [],
+    "bar": {}
+}
+JSON;
+
+        $this->assertSame($original, Json\Json::prettyPrint($original));
+    }
+
+    public function testPrettyPrintEmptyPropertiesWithWhitespace()
+    {
+        $original = <<<JSON
+{
+"foo": [
+
+            ],
+    "bar": {
+    
+    
+}
+}
+JSON;
+
+        $pretty = <<<JSON
+{
+    "foo": [],
+    "bar": {}
+}
+JSON;
+
+        $this->assertSame($pretty, Json\Json::prettyPrint($original));
+    }
+
     public function testJsonPrettyPrintDoesNotRemoveSpaceAroundCommaInStringValue()
     {
         $original = <<<JSON
 {
-    "space-after": "Level is greater than 9000, maybe even 9001!"
-    "space-around": "Really , nobody does that."
-    "within-array": [
+    "after": "Level is greater than 9000, maybe even 9001!",
+    "around": "Really , nobody does that.",
+    "in-array": [
         "Level is greater than 9000, maybe even 9001!",
         "Really , nobody does that."
-    ],
-    "within-object": {
-        "space-after": "Level is greater than 9000, maybe even 9001!"
-        "space-around": "Really , nobody does that."
-    }
+    ]
 }
 JSON;
 

--- a/test/JsonTest.php
+++ b/test/JsonTest.php
@@ -960,6 +960,28 @@ EOB;
         $this->assertSame($expected, $pretty);
     }
 
+    public function testJsonPrettyPrintDoesNotRemoveSpaceAroundCommaInStringValue()
+    {
+        $original = <<<JSON
+{
+    "space-after": "Level is greater than 9000, maybe even 9001!"
+    "space-around": "Really , nobody does that."
+    "within-array": [
+        "Level is greater than 9000, maybe even 9001!",
+        "Really , nobody does that."
+    ],
+    "within-object": {
+        "space-after": "Level is greater than 9000, maybe even 9001!"
+        "space-around": "Really , nobody does that."
+    }
+}
+JSON;
+
+        $pretty = Json\Json::prettyPrint($original);
+
+        $this->assertSame($original, $pretty);
+    }
+
     public function testPrettyPrintDoublequoteFollowingEscapedBackslashShouldNotBeTreatedAsEscaped()
     {
         $this->assertEquals(

--- a/test/JsonTest.php
+++ b/test/JsonTest.php
@@ -960,6 +960,19 @@ EOB;
         $this->assertSame($expected, $pretty);
     }
 
+    public function testPrettyPrintDoublequoteFollowingEscapedBackslashShouldNotBeTreatedAsEscaped()
+    {
+        $this->assertEquals(
+            "[\n    1,\n    \"\\\\\",\n    3\n]",
+            Json\Json::prettyPrint(Json\Json::encode([1, '\\', 3]))
+        );
+
+        $this->assertEquals(
+            "{\n    \"a\": \"\\\\\"\n}",
+            Json\Json::prettyPrint(Json\Json::encode(['a' => '\\']))
+        );
+    }
+
     public function testPrettyPrintEmptyArray()
     {
         $original = <<<JSON
@@ -1056,19 +1069,6 @@ JSON;
 JSON;
 
         $this->assertSame($original, Json\Json::prettyPrint($original));
-    }
-
-    public function testPrettyPrintDoublequoteFollowingEscapedBackslashShouldNotBeTreatedAsEscaped()
-    {
-        $this->assertEquals(
-            "[\n    1,\n    \"\\\\\",\n    3\n]",
-            Json\Json::prettyPrint(Json\Json::encode([1, '\\', 3]))
-        );
-
-        $this->assertEquals(
-            "{\n    \"a\": \"\\\\\"\n}",
-            Json\Json::prettyPrint(Json\Json::encode(['a' => '\\']))
-        );
     }
 
     public function testPrettyPrintRePrettyPrint()


### PR DESCRIPTION
This PR

* [x] asserts that a space after a `,` in `string` value is left alone
* [x] leaves the space after a `,` in a string value alone

Fixes #2.

💁‍♂️ Not sure if a fix yet, but figured I provide a failing test at least.