### PR TITLE
Fix: Do not print empty arrays and objects with new lines 

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -171,8 +171,19 @@ class Json
         $indentString = isset($options['indent']) ? $options['indent'] : '    ';
         $inLiteral    = false;
 
-        foreach ($tokens as $token) {
-            $token = trim($token);
+        $openingBrackets = ['{', '['];
+        $closingBrackets = ['}', ']'];
+
+        $bracketPairs = array_combine(
+            $openingBrackets,
+            $closingBrackets
+        );
+
+        $count = count($tokens);
+
+        for ($i = 0; $i < $count; ++$i) {
+            $token = trim($tokens[$i]);
+
             if ($token === '') {
                 continue;
             }
@@ -182,16 +193,35 @@ class Json
             }
 
             $prefix = str_repeat($indentString, $indentLevel);
-            if (! $inLiteral && ($token === '{' || $token === '[')) {
+            if (! $inLiteral && in_array($token, $openingBrackets, true)) {
                 $indentLevel++;
                 if ($result != '' && $result[strlen($result) - 1] === "\n") {
                     $result .= $prefix;
                 }
-                $result .= $token . "\n";
+                $result .= $token;
+
+                $closingBracket = $bracketPairs[$token];
+
+                do {
+                    ++$i;
+                } while ($i < $count && '' === trim($tokens[$i]));
+
+                if ($closingBracket === $tokens[$i]) {
+                    --$indentLevel;
+
+                    $result .= $tokens[$i];
+
+                    continue;
+                }
+
+                --$i;
+
+                $result .= "\n";
+
                 continue;
             }
 
-            if (! $inLiteral && ($token == '}' || $token == ']')) {
+            if (! $inLiteral && in_array($token, $closingBrackets, true)) {
                 $indentLevel--;
                 $prefix = str_repeat($indentString, $indentLevel);
                 $result .= "\n" . $prefix . $token;

--- a/test/JsonTest.php
+++ b/test/JsonTest.php
@@ -974,6 +974,59 @@ EOB;
         );
     }
 
+    public function testPrettyPrintEmptyArray()
+    {
+        $original = <<<JSON
+[]
+JSON;
+
+        $this->assertSame($original, Json\Json::prettyPrint($original));
+    }
+
+    public function testPrettyPrintEmptyObject()
+    {
+        $original = <<<JSON
+{}
+JSON;
+
+        $this->assertSame($original, Json\Json::prettyPrint($original));
+    }
+
+    public function testPrettyPrintEmptyProperties()
+    {
+        $original = <<<JSON
+{
+    "foo": [],
+    "bar": {}
+}
+JSON;
+
+        $this->assertSame($original, Json\Json::prettyPrint($original));
+    }
+    public function testPrettyPrintEmptyPropertiesWithWhitespace()
+    {
+        $original = <<<JSON
+{
+"foo": [
+
+            ],
+    "bar": {
+    
+    
+}
+}
+JSON;
+
+        $pretty = <<<JSON
+{
+    "foo": [],
+    "bar": {}
+}
+JSON;
+
+        $this->assertSame($pretty, Json\Json::prettyPrint($original));
+    }
+
     public function testPrettyPrintRePrettyPrint()
     {
         $expected = <<<EOB


### PR DESCRIPTION
This PR

* [x] asserts that empty arrays and objects are printed without new lines
* [x] looks ahead for closing brackets and skips new lines if there's only whitespace in-between