### PR TITLE
Fix: replace curly offset access brace with square brackets

### DIFF
--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -107,7 +107,7 @@ class Decoder
                     $i += 5;
                     break;
                 case ($ordChrsC >= 0x20) && ($ordChrsC <= 0x7F):
-                    $utf8 .= $chrs{$i};
+                    $utf8 .= $chrs[$i];
                     break;
                 case ($ordChrsC & 0xE0) == 0xC0:
                     // characters U-00000080 - U-000007FF, mask 110XXXXX
@@ -362,7 +362,7 @@ class Decoder
         $i         = $this->offset;
         $start     = $i;
 
-        switch ($str{$i}) {
+        switch ($str[$i]) {
             case '{':
                 $this->token = self::LBRACE;
                 break;
@@ -389,7 +389,7 @@ class Decoder
                         break;
                     }
 
-                    $chr = $str{$i};
+                    $chr = $str[$i];
 
                     if ($chr === '"') {
                         break;
@@ -406,7 +406,7 @@ class Decoder
                         break;
                     }
 
-                    $chr = $str{$i};
+                    $chr = $str[$i];
                     switch ($chr) {
                         case '"':
                             $result .= '"';
@@ -471,7 +471,7 @@ class Decoder
             return ($this->token);
         }
 
-        $chr = $str{$i};
+        $chr = $str[$i];
 
         if ($chr !== '-' && $chr !== '.' && ($chr < '0' || $chr > '9')) {
             throw new RuntimeException('Illegal Token');
@@ -521,7 +521,7 @@ class Decoder
             return mb_convert_encoding($utf16, 'UTF-8', 'UTF-16');
         }
 
-        $bytes = (ord($utf16{0}) << 8) | ord($utf16{1});
+        $bytes = (ord($utf16[0]) << 8) | ord($utf16[1]);
 
         switch (true) {
             case ((0x7F & $bytes) == $bytes):

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -585,14 +585,14 @@ class Encoder
             case 2:
                 // Return a UTF-16 character from a 2-byte UTF-8 char;
                 // see: http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                return chr(0x07 & (ord($utf8{0}) >> 2)) . chr((0xC0 & (ord($utf8{0}) << 6)) | (0x3F & ord($utf8{1})));
+                return chr(0x07 & (ord($utf8[0]) >> 2)) . chr((0xC0 & (ord($utf8[0]) << 6)) | (0x3F & ord($utf8[1])));
 
             case 3:
                 // Return a UTF-16 character from a 3-byte UTF-8 char;
                 // see: http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                return chr((0xF0 & (ord($utf8{0}) << 4))
-                    | (0x0F & (ord($utf8{1}) >> 2))) . chr((0xC0 & (ord($utf8{1}) << 6))
-                    | (0x7F & ord($utf8{2})));
+                return chr((0xF0 & (ord($utf8[0]) << 4))
+                    | (0x0F & (ord($utf8[1]) >> 2))) . chr((0xC0 & (ord($utf8[1]) << 6))
+                    | (0x7F & ord($utf8[2])));
         }
 
         // ignoring UTF-32 for now, sorry


### PR DESCRIPTION
As of PHP 7.4 using curly brackets is deprecated.

Fixes #45

- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->